### PR TITLE
use 16x system tray icon

### DIFF
--- a/Source/Forms/NetGraphForm.cs
+++ b/Source/Forms/NetGraphForm.cs
@@ -27,7 +27,7 @@ namespace ScriptFUSION.UpDown_Meter {
             Options = new Options(Settings.Default);
 
             trayIconIllustrator = new TrayIconIllustrator();
-            trayIcon.Icon = Icon;
+            trayIcon.Icon = Properties.Resources.udm;
 
             // Timer does not fire at start-up so trigger manually.
             timer_Tick(null, null);

--- a/Source/Forms/NetGraphForm.cs
+++ b/Source/Forms/NetGraphForm.cs
@@ -27,7 +27,7 @@ namespace ScriptFUSION.UpDown_Meter {
             Options = new Options(Settings.Default);
 
             trayIconIllustrator = new TrayIconIllustrator();
-            trayIcon.Icon = Properties.Resources.udm;
+            trayIcon.Icon = new Icon(Properties.Resources.udm, SystemInformation.SmallIconSize);  
 
             // Timer does not fire at start-up so trigger manually.
             timer_Tick(null, null);

--- a/Source/Properties/Resources.Designer.cs
+++ b/Source/Properties/Resources.Designer.cs
@@ -121,6 +121,16 @@ namespace ScriptFUSION.UpDown_Meter.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Icon similar to (Icon).
+        /// </summary>
+        internal static System.Drawing.Icon udm {
+            get {
+                object obj = ResourceManager.GetObject("udm", resourceCulture);
+                return ((System.Drawing.Icon)(obj));
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap UDM_banner {

--- a/Source/Properties/Resources.resx
+++ b/Source/Properties/Resources.resx
@@ -139,4 +139,7 @@
   <data name="refresh" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\reset.gif;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="udm" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\udm.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
 </root>


### PR DESCRIPTION
I added the icon to the resources file. Then instead of using the form icon (32x) to use the icon from resources, and also telling it use the small icon size 16x by default.

This should address bug #6 